### PR TITLE
Fix integral type inference

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ Test = "1.7 - 1"
 [extras]
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 
 [targets]
-test = ["Test", "Statistics"]
+test = ["Test", "Statistics", "ForwardDiff"]

--- a/src/types.jl
+++ b/src/types.jl
@@ -29,7 +29,7 @@ struct NumericallyIntegrable{F, T <: Real, I} <: ContinuousUnivariateDistributio
         integral = quadgk(f, support...)[1]
         F = typeof(f)
         T = eltype(support)
-        I = eltype(integral)
+        I = typeof(integral)
         new{F, T, I}(f, integral, support, n_sampling_bins)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@ using Statistics
 using Random
 using QuadGK
 using Test
+using ForwardDiff
 
 @testset "Basic functionality" begin
     # Test with a simple normal distribution truncated to [-2, 2]
@@ -138,4 +139,9 @@ b = Interpolated(x -> abs(x), -2:0.5:1; degree = Linear())
     @test cdf(b, 2.0) == 1.0
     @test cdf(b, 0.0) ≈ 0.8
     @test b.integral ≈ 2.5
+end
+@testset "typeof vs eltype" begin
+    g(x, p) = p * x
+    h(p) = NumericallyIntegrable(x -> g(x, p), (0.0, 1.0)).integral
+    @test isapprox(ForwardDiff.derivative(h, 2.0), 0.5; atol = 1e-12)
 end


### PR DESCRIPTION
## Summary
- fix type inference when computing the normalization constant
- add ForwardDiff to test dependencies
- test that AD works when the integral returns a dual number

## Testing
- `julia --project -e "using Pkg; Pkg.test()"` *(fails to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68404e02dcd0832b8724fcc15caa6e6c