### PR TITLE
Fix integral field docstring

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -5,7 +5,7 @@ A continuous univariate distribution defined by an unnormalized probability dens
 
 # Fields
 - `unnormalized_pdf::F`: The unnormalized probability density function
-- `integral::Float64`: The normalization constant (integral of the PDF)
+- `integral::I`: The normalization constant (integral of the PDF)
 - `support::S`: The support range of the distribution (default: (-Inf, Inf))
 - `n_sampling_bins::Int`: Number of bins used for sampling approximation
 


### PR DESCRIPTION
## Summary
- clarify the `integral` field type in the docstring for `NumericallyIntegrable`

## Testing
- `julia --project -e 'using Pkg; Pkg.test()'`

------
https://chatgpt.com/codex/tasks/task_e_684081c6b118832bbb99fee4196e93a1