### PR TITLE
Fix codecov-action option in ReusableTest.yml

### DIFF
--- a/.github/workflows/ReusableTest.yml
+++ b/.github/workflows/ReusableTest.yml
@@ -48,5 +48,5 @@ jobs:
             - uses: codecov/codecov-action@v5
               if: ${{ inputs.run_codecov }}
               with:
-                  file: lcov.info
+                  files: lcov.info
                   token: ${{ secrets.codecov_token }}


### PR DESCRIPTION
codecov-action v5 replaced `file:` option with `files:`